### PR TITLE
Keep directory in filename in DirectoryReadTool

### DIFF
--- a/crewai_tools/tools/directory_read_tool/directory_read_tool.py
+++ b/crewai_tools/tools/directory_read_tool/directory_read_tool.py
@@ -29,5 +29,5 @@ class DirectoryReadTool(BaseTool):
 		**kwargs: Any,
 	) -> Any:
 		directory = kwargs.get('directory', self.directory)
-		return [(os.path.join(root, file).replace(directory, "").lstrip(os.path.sep)) for root, dirs, files in os.walk(directory) for file in files]
+		return [os.path.join(root, file) for root, dirs, files in os.walk(directory) for file in files]
 


### PR DESCRIPTION
@joaomdmoura  Don't remove the directory from the filename. Otherwise FileReadTool will not be able to find the file if it is not in the same directory