### PR TITLE
Fix NoneType object has no attribute 'query' error by updating app attribute

### DIFF
--- a/crewai_tools/tools/github_search_tool/github_search_tool.py
+++ b/crewai_tools/tools/github_search_tool/github_search_tool.py
@@ -41,4 +41,5 @@ class GithubSearchTool(RagTool):
 		loader = GithubLoader(config={"token": self.gh_token})
 		app = App()
 		app.add(f"repo:{github_repo} type:{','.join(self.content_types)}", data_type="github", loader=loader)
+		self.app = app
 		return super()._run(query=search_query)


### PR DESCRIPTION
#### Problem Overview
While working with the GithubSearchTool, which extends the functionality of the RagTool, I encountered a critical issue. Specifically, when attempting to use the tool for semantic searches within a GitHub repository, the process failed, throwing a `'NoneType' object has no attribute 'query'` error. This error was directly tied to the `RagTool`'s `adapter` attribute not being properly initialized with an `App` instance from `embedchain`. As a result, any attempt to query the knowledge base through the `adapter` led to a failure, significantly impacting the usability of the GithubSearchTool.

#### Root Cause Analysis
Upon diving into the codebase, I identified that the `RagTool` class was designed to use an `adapter` for querying, which in turn relies on an `App` instance (from the `embedchain` package) for its operation. However, there was no explicit initialization or assignment of the `App` instance to the `RagTool`, leading to the `adapter` being `None` when its `query` method was called. This oversight was the root cause of the aforementioned error.

#### Implemented Solution
To resolve this issue, I made the following changes:
- **File Modified**: `crewAI-tools/crewai_tools/tools/github_search_tool/github_search_tool.py`
- **Change Details**: I added a line `self.app = app` within the `GithubSearchTool` class's `_run` method. This ensures that before any querying occurs, the `App` instance is properly initialized and assigned, facilitating the correct operation of the `adapter`.

This modification ensures that the `RagTool` now has a valid `App` instance before any query operation, thereby eliminating the `NoneType` object error and significantly improving the tool's reliability and functionality.

#### Why This Solution?
This solution directly addresses the initialization issue by ensuring the `App` instance is properly set up within the `RagTool`. It's a minimal and efficient fix that resolves the error without introducing any additional dependencies or complexities into the codebase. By fixing this issue, we enhance the robustness of the GithubSearchTool and, by extension, any other tools relying on the `RagTool` framework.

I believe this fix will significantly improve the developer experience and reliability of the GithubSearchTool.