### PR TITLE
Fix TypeError in DOCXSearchTool Schema

### DIFF
--- a/crewai_tools/tools/docx_search_tool/docx_search_tool.py
+++ b/crewai_tools/tools/docx_search_tool/docx_search_tool.py
@@ -8,7 +8,7 @@ from ..rag.rag_tool import RagTool
 
 class FixedDOCXSearchToolSchema(BaseModel):
     """Input for DOCXSearchTool."""
-    docx: Optional[str] = Field(..., description="Mandatory docx path you want to search")
+    docx: str = Optional[Field](..., description="Mandatory docx path you want to search")
     search_query: str = Field(
         ...,
         description="Mandatory search query you want to use to search the DOCX's content",

--- a/crewai_tools/tools/docx_search_tool/docx_search_tool.py
+++ b/crewai_tools/tools/docx_search_tool/docx_search_tool.py
@@ -8,7 +8,7 @@ from ..rag.rag_tool import RagTool
 
 class FixedDOCXSearchToolSchema(BaseModel):
     """Input for DOCXSearchTool."""
-    docx: str = Optional[Field](..., description="Mandatory docx path you want to search")
+    docx: Optional[str] = Field(..., description="Mandatory docx path you want to search")
     search_query: str = Field(
         ...,
         description="Mandatory search query you want to use to search the DOCX's content",


### PR DESCRIPTION
This pull request addresses a `TypeError` encountered in the `FixedDOCXSearchToolSchema` due to incorrect usage of `Optional` with `Field`. The error was triggered during the import process, causing instantiation issues with `typing.Union`.

#### Changes
- Corrected the usage of `Optional` in the `docx_search_tool.py` to properly define optional fields with Pydantic's `Field`.

#### Technical Details
- **File Affected**: `docx_search_tool.py`
- **Error Trace**:
  ```
  TypeError: Cannot instantiate typing.Union
  ```
  This error occurred due to an attempt to instantiate `Optional` as a class, which is not permissible. `Optional` should be used as a type hint, not as a callable.

#### Resolution
Updated the field definition to:
```python
docx: Optional[str] = Field(..., description="Mandatory docx path you want to search")
```

This update ensures that the `docx` field correctly accepts a string or `None` as intended, aligning with Python's type hinting and Pydantic's model validation system.
